### PR TITLE
fix: new plugin version

### DIFF
--- a/octosql_manifest.json
+++ b/octosql_manifest.json
@@ -2,7 +2,7 @@
   "binary_download_url_pattern": "https://github.com/cube2222/octosql-plugin-mysql/releases/download/{{version}}/octosql-plugin-mysql_{{version}}_{{os}}_{{arch}}.tar.gz",
   "versions": [
     {
-      "number": "0.1.0"
+      "number": "0.2.0"
     },
     {
       "number": "0.1.0"


### PR DESCRIPTION
Version 0.2.0 of the plugin was released, but it was not possible to install it conventionally.